### PR TITLE
switch instance types to m5.large

### DIFF
--- a/templates/nsolid-console-ecs-with-cluster.json
+++ b/templates/nsolid-console-ecs-with-cluster.json
@@ -371,7 +371,7 @@
             "Ref": "HostSecurityGroup"
           }
         ],
-        "InstanceType": "m3.large",
+        "InstanceType": "m5.large",
         "KeyName": {
           "Ref": "SSHKey"
         },

--- a/templates/nsolid-console-elb.json
+++ b/templates/nsolid-console-elb.json
@@ -222,7 +222,7 @@
             "Ref": "ConsoleSecurityGroup"
           }
         ],
-        "InstanceType": "m3.large",
+        "InstanceType": "m5.large",
         "KeyName": {
           "Ref": "SSHKey"
         }

--- a/templates/nsolid-console-nlb.json
+++ b/templates/nsolid-console-nlb.json
@@ -312,7 +312,7 @@
             "Ref": "ConsoleSecurityGroup"
           }
         ],
-        "InstanceType": "m3.large",
+        "InstanceType": "m5.large",
         "KeyName": {
           "Ref": "SSHKey"
         }

--- a/templates/nsolid-console-only.json
+++ b/templates/nsolid-console-only.json
@@ -136,7 +136,7 @@
             "AMI"
           ]
         },
-        "InstanceType": "m3.large",
+        "InstanceType": "m5.large",
         "KeyName": {
           "Ref": "SSHKey"
         },

--- a/templates/nsolid-console-route53.json
+++ b/templates/nsolid-console-route53.json
@@ -144,7 +144,7 @@
             "AMI"
           ]
         },
-        "InstanceType": "m3.large",
+        "InstanceType": "m5.large",
         "KeyName": {
           "Ref": "SSHKey"
         },

--- a/templates/nsolid-quick-start.json
+++ b/templates/nsolid-quick-start.json
@@ -189,7 +189,7 @@
             "AMI"
           ]
         },
-        "InstanceType": "m3.large",
+        "InstanceType": "m5.large",
         "KeyName": {
           "Ref": "SSHKey"
         },
@@ -230,7 +230,7 @@
             "AMI"
           ]
         },
-        "InstanceType": "m3.large",
+        "InstanceType": "m5.large",
         "KeyName": {
           "Ref": "SSHKey"
         },

--- a/templates/nsolid-runtime-only.json
+++ b/templates/nsolid-runtime-only.json
@@ -124,7 +124,7 @@
             "AMI"
           ]
         },
-        "InstanceType": "m3.large",
+        "InstanceType": "m5.large",
         "KeyName": {
           "Ref": "SSHKey"
         },


### PR DESCRIPTION
m3 instance types are deprecated, this moves the instances to m5.large